### PR TITLE
Upgrades to wasmtime 0.18.0 and removes mut from call function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wapc"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["waPC team <alothien@gmail.com>"]
 edition = "2018"
 description = "Rust WebAssembly Host Runtime Conforming to the waPC Standard"
@@ -15,10 +15,9 @@ exclude = [".assets"]
 [dependencies]
 log = "0.4.8"
 env_logger = "0.7"
-serde = "1.0.110"
-serde_derive = "1.0.110"
-serde_json = "1.0.53"
-wasmtime = "0.16.0"
-wasmtime-wasi = "0.16.0"
-anyhow = "1.0"
-wasi-common = "0.16.0"
+serde = { version = "1.0.114", features = ["derive"] }
+serde_json = "1.0.55"
+wasmtime = "0.18.0"
+wasmtime-wasi = "0.18.0"
+anyhow = "1.0.31"
+wasi-common = "0.18.0"

--- a/examples/asdemo.rs
+++ b/examples/asdemo.rs
@@ -13,7 +13,7 @@ fn load_file() -> Vec<u8> {
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let module_bytes = load_file();
-    let mut host = WapcHost::new(host_callback, &module_bytes, None)?;
+    let host = WapcHost::new(host_callback, &module_bytes, None)?;
 
     println!("Calling guest (wasm) function written in AssemblyScript");
     let res = host.call("hello", b"this is a test")?;

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -13,7 +13,7 @@ fn load_file() -> Vec<u8> {
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let module_bytes = load_file();
-    let mut host = WapcHost::new(host_callback, &module_bytes, None)?;
+    let host = WapcHost::new(host_callback, &module_bytes, None)?;
 
     println!("Calling guest (wasm) function");
     let res = host.call("wapc:sample!Hello", b"this is a test")?;

--- a/examples/demo_logger.rs
+++ b/examples/demo_logger.rs
@@ -13,7 +13,7 @@ fn load_file() -> Vec<u8> {
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let module_bytes = load_file();
-    let mut host = WapcHost::new_with_logger(host_callback, &module_bytes, logger, None)?;
+    let host = WapcHost::new_with_logger(host_callback, &module_bytes, logger, None)?;
 
     println!("Calling guest (wasm) function");
     let res = host.call("wapc:sample!Hello", b"this is a test")?;

--- a/examples/tinygodemo.rs
+++ b/examples/tinygodemo.rs
@@ -13,7 +13,7 @@ fn load_file() -> Vec<u8> {
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let module_bytes = load_file();
-    let mut host = WapcHost::new(host_callback, &module_bytes, None)?;
+    let host = WapcHost::new(host_callback, &module_bytes, None)?;
 
     println!("Calling guest (wasm) function written in TinyGo");
     let res = host.call("hello", b"this is a test")?;

--- a/examples/zigdemo.rs
+++ b/examples/zigdemo.rs
@@ -13,7 +13,7 @@ fn load_file() -> Vec<u8> {
 pub fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
     let module_bytes = load_file();
-    let mut host = WapcHost::new(host_callback, &module_bytes, None)?;
+    let host = WapcHost::new(host_callback, &module_bytes, None)?;
 
     println!("Calling guest (wasm) function written in Zig");
     let res = host.call("hello", b"this is a test")?;

--- a/src/callbacks.rs
+++ b/src/callbacks.rs
@@ -3,7 +3,7 @@ use crate::{HostCallback, LogCallback};
 use std::cell::RefCell;
 use std::rc::Rc;
 use wasmtime::Memory;
-use wasmtime::{Caller, Func, FuncType, HostRef, Store, Val, ValType};
+use wasmtime::{Caller, Func, FuncType, Store, Val, ValType};
 
 #[derive(Default)]
 pub(crate) struct ModuleState {
@@ -257,15 +257,14 @@ pub(crate) fn host_error_len_func(store: &Store, state: Rc<RefCell<ModuleState>>
     )
 }
 
-fn get_caller_memory(caller: &Caller) -> Result<HostRef<Memory>, anyhow::Error> {
+fn get_caller_memory(caller: &Caller) -> Result<Memory, anyhow::Error> {
     let memory = caller
         .get_export("memory")
         .map(|e| e.into_memory().unwrap());
-    Ok(HostRef::new(memory.unwrap()))
+    Ok(memory.unwrap())
 }
 
-fn get_vec_from_memory(mem: HostRef<Memory>, ptr: i32, len: i32) -> Vec<u8> {
-    let mem = mem.borrow_mut();
+fn get_vec_from_memory(mem: Memory, ptr: i32, len: i32) -> Vec<u8> {
     let data = unsafe { mem.data_unchecked_mut() };
     data[ptr as usize..(ptr + len) as usize]
         .iter()
@@ -273,8 +272,7 @@ fn get_vec_from_memory(mem: HostRef<Memory>, ptr: i32, len: i32) -> Vec<u8> {
         .collect()
 }
 
-fn write_bytes_to_memory(memory: HostRef<Memory>, ptr: i32, slice: &[u8]) {
-    let memory = memory.borrow_mut();
+fn write_bytes_to_memory(memory: Memory, ptr: i32, slice: &[u8]) {
     let data = unsafe { memory.data_unchecked_mut() };
     // TODO: upgrade this to a faster memory write
     for idx in 0..slice.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,7 +264,7 @@ impl WapcHost {
     /// It is worth noting that the _first_ time `call` is invoked, the WebAssembly module
     /// will be JIT-compiled. This can take up to a few seconds on debug .wasm files, but
     /// all subsequent calls will be "hot" and run at near-native speeds.    
-    pub fn call(self, op: &str, payload: &[u8]) -> Result<Vec<u8>> {
+    pub fn call(&self, op: &str, payload: &[u8]) -> Result<Vec<u8>> {
         let inv = Invocation::new(op, payload.to_vec());
 
         {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@
 //! # }
 //! pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let module_bytes = load_file();
-//!     let mut host = WapcHost::new(|id: u64, bd: &str, ns: &str, op: &str, payload: &[u8]| {
+//!     let host = WapcHost::new(|id: u64, bd: &str, ns: &str, op: &str, payload: &[u8]| {
 //!         println!("Guest {} invoked '{}->{}:{}' with payload of {} bytes", id, bd, ns, op, payload.len());
 //!         Ok(vec![])
 //!     }, &module_bytes, None)?;
@@ -76,7 +76,7 @@ use wasmtime::*;
 
 macro_rules!  call {
     ($func:expr, $($p:expr),*) => {
-      match $func.borrow().call(&[$($p.into()),*]) {
+      match $func.call(&[$($p.into()),*]) {
         Ok(result) => {
           let result: i32 = result[0].i32().unwrap();
           result
@@ -171,7 +171,7 @@ pub struct WapcHost {
     state: Rc<RefCell<ModuleState>>,
     instance: Rc<RefCell<Option<Instance>>>,
     wasidata: Option<WasiParams>,
-    guest_call_fn: HostRef<Func>,
+    guest_call_fn: Func,
 }
 
 impl WapcHost {
@@ -264,7 +264,7 @@ impl WapcHost {
     /// It is worth noting that the _first_ time `call` is invoked, the WebAssembly module
     /// will be JIT-compiled. This can take up to a few seconds on debug .wasm files, but
     /// all subsequent calls will be "hot" and run at near-native speeds.    
-    pub fn call(&mut self, op: &str, payload: &[u8]) -> Result<Vec<u8>> {
+    pub fn call(self, op: &str, payload: &[u8]) -> Result<Vec<u8>> {
         let inv = Invocation::new(op, payload.to_vec());
 
         {
@@ -335,7 +335,7 @@ impl WapcHost {
     ) -> Result<Instance> {
         let engine = Engine::default();
         let store = Store::new(&engine);
-        let module = Module::new(&store, buf).unwrap();
+        let module = Module::new(&engine, buf).unwrap();
 
         let d = WasiParams::default();
         let wasi = match wasi {
@@ -353,7 +353,7 @@ impl WapcHost {
 
         let imports = arrange_imports(&module, state.clone(), store.clone(), &module_registry);
 
-        Ok(wasmtime::Instance::new(&module, imports?.as_slice()).unwrap())
+        Ok(wasmtime::Instance::new(&store, &module, imports?.as_slice()).unwrap())
     }
 
     fn initialize(&self) -> Result<()> {
@@ -364,11 +364,15 @@ impl WapcHost {
             .unwrap()
             .get_export("_start")
         {
-            ext.into_func().unwrap().call(&[]).map(|_| ()).map_err(|_err| {
-                errors::new(errors::ErrorKind::GuestCallFailure(
-                    "Error invoking _start function!".to_string(),
-                ))
-            })
+            ext.into_func()
+                .unwrap()
+                .call(&[])
+                .map(|_| ())
+                .map_err(|_err| {
+                    errors::new(errors::ErrorKind::GuestCallFailure(
+                        "Error invoking _start function!".to_string(),
+                    ))
+                })
         } else {
             Ok(())
         }
@@ -377,9 +381,9 @@ impl WapcHost {
 
 // Called once, then the result is cached. This returns a `Func` that corresponds
 // to the `__guest_call` export
-fn guest_call_fn(instance: Rc<RefCell<Option<Instance>>>) -> Result<HostRef<Func>> {
-    if let Some(ext) = instance.borrow().as_ref().unwrap().get_export(GUEST_CALL) {
-        Ok(HostRef::new(ext.into_func().unwrap().clone()))
+fn guest_call_fn(instance: Rc<RefCell<Option<Instance>>>) -> Result<Func> {
+    if let Some(func) = instance.borrow().as_ref().unwrap().get_func(GUEST_CALL) {
+        Ok(func)
     } else {
         Err(errors::new(errors::ErrorKind::GuestCallFailure(
             "Guest module did not export __guest_call function!".to_string(),
@@ -399,7 +403,7 @@ fn arrange_imports(
     mod_registry: &ModuleRegistry,
 ) -> Result<Vec<Extern>> {
     Ok(module
-        .imports()        
+        .imports()
         .filter_map(|imp| {
             if let ExternType::Func(_) = imp.ty() {
                 match imp.module() {


### PR DESCRIPTION
* Upgrade all wasmtime dependencies to 0.18.0
* Remove the mutability requirement from the `call` function, thereby making `WapcHost` usable without ever being mutable.

FYI @andrisak