### PR TITLE
Feature/add send sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wapc"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["waPC team <alothien@gmail.com>"]
 edition = "2018"
 description = "Rust WebAssembly Host Runtime Conforming to the waPC Standard"

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The following is a simple example of synchronous, bi-directional procedure calls
 extern crate wapc;
 use wapc::prelude::*;
 
-pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+pub fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let module = load_file();
     let mut host = WapcHost::new(|id: u64, bd: &str, ns: &str, op: &str, payload: &str|{
         println!("Guest {} invoked '{}->{}:{}' with payload of {} bytes", id, bd, ns, op, payload.len());

--- a/examples/asdemo.rs
+++ b/examples/asdemo.rs
@@ -10,7 +10,7 @@ fn load_file() -> Vec<u8> {
     buf
 }
 
-pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+pub fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     env_logger::init();
     let module_bytes = load_file();
     let host = WapcHost::new(host_callback, &module_bytes, None)?;
@@ -28,7 +28,7 @@ fn host_callback(
     ns: &str,
     op: &str,
     payload: &[u8],
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
     println!(
         "Guest {} invoked '{}->{}:{}' with payload of {}",
         id,

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -10,7 +10,7 @@ fn load_file() -> Vec<u8> {
     buf
 }
 
-pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+pub fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     env_logger::init();
     let module_bytes = load_file();
     let host = WapcHost::new(host_callback, &module_bytes, None)?;
@@ -28,7 +28,7 @@ fn host_callback(
     ns: &str,
     op: &str,
     payload: &[u8],
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
     println!(
         "Guest {} invoked '{}->{}:{}' with payload of {}",
         id,

--- a/examples/demo_logger.rs
+++ b/examples/demo_logger.rs
@@ -10,7 +10,7 @@ fn load_file() -> Vec<u8> {
     buf
 }
 
-pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+pub fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     env_logger::init();
     let module_bytes = load_file();
     let host = WapcHost::new_with_logger(host_callback, &module_bytes, logger, None)?;
@@ -28,7 +28,7 @@ fn host_callback(
     ns: &str,
     op: &str,
     payload: &[u8],
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
     println!(
         "Guest {} invoked '{}->{}:{}' with payload of {}",
         id,
@@ -40,7 +40,7 @@ fn host_callback(
     Ok(vec![])
 }
 
-fn logger(id: u64, msg: &str) -> Result<(), Box<dyn std::error::Error>> {
+fn logger(id: u64, msg: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     println!("***> [{}] {}", id, msg);
     Ok(())
 }

--- a/examples/tinygodemo.rs
+++ b/examples/tinygodemo.rs
@@ -10,7 +10,7 @@ fn load_file() -> Vec<u8> {
     buf
 }
 
-pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+pub fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     env_logger::init();
     let module_bytes = load_file();
     let host = WapcHost::new(host_callback, &module_bytes, None)?;
@@ -28,7 +28,7 @@ fn host_callback(
     ns: &str,
     op: &str,
     payload: &[u8],
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
     println!(
         "Guest {} invoked '{}->{}:{}' with payload of {}",
         id,

--- a/examples/zigdemo.rs
+++ b/examples/zigdemo.rs
@@ -10,7 +10,7 @@ fn load_file() -> Vec<u8> {
     buf
 }
 
-pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+pub fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     env_logger::init();
     let module_bytes = load_file();
     let host = WapcHost::new(host_callback, &module_bytes, None)?;
@@ -28,7 +28,7 @@ fn host_callback(
     ns: &str,
     op: &str,
     payload: &[u8],
-) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+) -> Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>> {
     println!(
         "Guest {} invoked '{}->{}:{}' with payload of {}",
         id,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -29,7 +29,7 @@ pub enum ErrorKind {
     NoSuchFunction(String),
     IO(std::io::Error),
     WasmMisc(String),
-    HostCallFailure(Box<dyn StdError>),
+    HostCallFailure(Box<dyn StdError + Sync + Send>),
     GuestCallFailure(String),
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -86,3 +86,12 @@ impl From<std::io::Error> for Error {
         Error(Box::new(ErrorKind::IO(source)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    #[allow(dead_code)]
+    fn assert_sync_send<T: Send + Sync>() {}
+    const _: fn() = || {
+        assert_sync_send::<super::Error>()
+    };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! # fn load_wasi_file() -> Vec<u8> {
 //! #    include_bytes!("../.assets/hello_wasi.wasm").to_vec()
 //! # }
-//! pub fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! pub fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 //!     let module_bytes = load_file();
 //!     let host = WapcHost::new(|id: u64, bd: &str, ns: &str, op: &str, payload: &[u8]| {
 //!         println!("Guest {} invoked '{}->{}:{}' with payload of {} bytes", id, bd, ns, op, payload.len());
@@ -111,12 +111,12 @@ const GUEST_CALL: &str = "__guest_call";
 const WASI_UNSTABLE_NAMESPACE: &str = "wasi_unstable";
 const WASI_SNAPSHOT_PREVIEW1_NAMESPACE: &str = "wasi_snapshot_preview1";
 
-type HostCallback = dyn Fn(u64, &str, &str, &str, &[u8]) -> std::result::Result<Vec<u8>, Box<dyn std::error::Error>>
+type HostCallback = dyn Fn(u64, &str, &str, &str, &[u8]) -> std::result::Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>
     + Sync
     + Send
     + 'static;
 
-type LogCallback = dyn Fn(u64, &str) -> std::result::Result<(), Box<dyn std::error::Error>>
+type LogCallback = dyn Fn(u64, &str) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>
     + Sync
     + Send
     + 'static;
@@ -183,7 +183,7 @@ impl WapcHost {
                 &str,
                 &str,
                 &[u8],
-            ) -> std::result::Result<Vec<u8>, Box<dyn std::error::Error>>
+            ) -> std::result::Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>
             + 'static
             + Sync
             + Send,
@@ -217,12 +217,12 @@ impl WapcHost {
                 &str,
                 &str,
                 &[u8],
-            ) -> std::result::Result<Vec<u8>, Box<dyn std::error::Error>>
+            ) -> std::result::Result<Vec<u8>, Box<dyn std::error::Error + Send + Sync>>
             + 'static
             + Sync
             + Send,
         buf: &[u8],
-        logger: impl Fn(u64, &str) -> std::result::Result<(), Box<dyn std::error::Error>>
+        logger: impl Fn(u64, &str) -> std::result::Result<(), Box<dyn std::error::Error + Send + Sync>>
             + Sync
             + Send
             + 'static,


### PR DESCRIPTION
This makes the `Error` type `Send + Sync`. No other changes are needed, as `HostCallFailure` is never used. I did not remove it, as I assume other code could use it.

**This is a breaking change.**

This the first step towards https://github.com/wascc/wascc-host/issues/74 and follows the same reasoning here.